### PR TITLE
Have mongodb_play read from the already simulated clock

### DIFF
--- a/mongodb_store/scripts/mongodb_play.py
+++ b/mongodb_store/scripts/mongodb_play.py
@@ -174,8 +174,10 @@ class TopicPlayer(PlayerProcess):
                 msg = msg_time_tuple[0]
 
                 now = rospy.get_rostime()
-
-                now_in_sim = now - self.start_time_diff
+                try:
+                    now_in_sim = now - self.start_time_diff
+                except TypeError:
+                    rospy.sleep(self.start_time_diff - now)
 
                 # if we've missed our window
                 if publish_time < now_in_sim:


### PR DESCRIPTION
Mongodb_play is currently creating its own clock server which counteracts the already simulated clock server from the gazebo simulation. To have mongodb_play replay topics on the simulation, we'll have to subscribe to the current clock instead